### PR TITLE
Add prompt files and validation

### DIFF
--- a/.github/prompts/react-form.prompt.md
+++ b/.github/prompts/react-form.prompt.md
@@ -1,0 +1,17 @@
+# React Form Component Generation
+
+Your goal is to generate a new React form component.
+
+Ask for the form name and fields if not provided.
+
+## Requirements for the form:
+
+- Use form design system components: [design-system/Form.md](../docs/design-system/Form.md)
+- Use `react-hook-form` for form state management:
+  - Always define TypeScript types for your form data
+  - Prefer *uncontrolled* components using register
+  - Use `defaultValues` to prevent unnecessary rerenders
+- Use `yup` for validation:
+  - Create reusable validation schemas in separate files
+  - Use TypeScript types to ensure type safety
+  - Customize UX-friendly validation rules

--- a/.github/prompts/security-api.prompt.md
+++ b/.github/prompts/security-api.prompt.md
@@ -1,0 +1,8 @@
+# Secure REST API Review
+
+## Security Review Requirements:
+
+- Ensure all endpoints are protected by authentication and authorization
+- Validate all user inputs and sanitize data
+- Implement rate limiting and throttling
+- Implement logging and monitoring for security events

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "chat.promptFiles": true
+}


### PR DESCRIPTION
Add reusable prompt files and enable prompt file setting.

* **Add React Form Prompt File**
  - Create `.github/prompts/react-form.prompt.md` for generating a React form component.
  - Include requirements for form design system components, `react-hook-form`, and `yup` for validation.

* **Add Security API Prompt File**
  - Create `.github/prompts/security-api.prompt.md` for reusable security practices for REST APIs.
  - Include security review requirements such as authentication, authorization, input validation, rate limiting, and logging.

* **Enable Prompt Files Setting**
  - Add `.vscode/settings.json` to enable prompt files by setting `chat.promptFiles` to true.

